### PR TITLE
Add plugin for payment forwarding notifications

### DIFF
--- a/forward-notify.js
+++ b/forward-notify.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const Plugin = require('clightningjs');
+const request = require('superagent')
+
+const listenPlugin = new Plugin();
+
+const apiKey = process.env.LIFX_KEY
+const apiUrl = `https://api.lifx.com/v1/lights`
+
+const lifx = (selector, method, action, params) => request[method](`${apiUrl}/${selector}/${action}`).set('Authorization', `Bearer ${apiKey}`).send(params).then(console.log).catch(console.error)
+
+listenPlugin.subscribe('forward_event');
+listenPlugin.notifications.forward_event.on('forward_event', (params) => {
+  fs.writeFile('log', params.forward_event, () => {});
+
+  if ( params.forward_event.status == "settled" ) {
+    lifx('all', 'post', 'effects/breathe', { color: `blue brightness:0.8`, cycles: 1, period: 10, peak: 0.1 })
+  }
+});
+
+listenPlugin.start();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node app.js"
   },
   "dependencies": {
+    "clightningjs": "^0.1.1",
     "lightning-charge-client": "^0.1.10",
     "superagent": "^4.1.0"
   }


### PR DESCRIPTION
Deployment requirements:
- Install `clightningjs` package.
- Set the `LIFX_KEY` environment variable in the Lightning node process environment.
- Give execute permission to `forward-notify.js`.
- Run Lightning node with `--plugin="<path>/forward-notify.js"` argument to run `forward-notify.js` as a plugin.

Any suggestions are welcome.